### PR TITLE
update to quartus prime lite 20.1, use unattended mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ADD files/ /
 # install quartus prime
 RUN mkdir -p /root/quartus && \
     cd /root/quartus && \
-    wget -q http://download.altera.com/akdlm/software/acdsinst/19.1std/670/ib_tar/Quartus-lite-19.1.0.670-linux.tar && \
-    tar xvf Quartus-lite-19.1.0.670-linux.tar && \
-    /root/setup 19.1 && rm -rf /root/quartus && rm -rf /root/setup*
+    wget -q http://download.altera.com/akdlm/software/acdsinst/20.1std/711/ib_tar/Quartus-lite-20.1.0.711-linux.tar && \
+    tar xvf Quartus-lite-20.1.0.711-linux.tar && \
+    /root/quartus/components/QuartusLiteSetup-20.1.0.711-linux.run --mode unattended --installdir /opt/intelFPGA_lite/20.1 --disable-components quartus_help,modelsim_ase,modelsim_ae --accept_eula 1 && \
+    rm -rf /root/quartus && rm -rf /root/setup*

--- a/files/root/.profile.addons
+++ b/files/root/.profile.addons
@@ -1,4 +1,4 @@
-export Q_INST_DIR=/opt/intelFPGA_lite/19.1
+export Q_INST_DIR=/opt/intelFPGA_lite/20.1
 
 export QUARTUS_ROOTDIR=${Q_INST_DIR}/quartus
 export SOPC_KIT_NIOS2=${Q_INST_DIR}/nios2eds


### PR DESCRIPTION
I've updated the links to use the latest Quartus Prime Lite 20.1 version. I also removed the need for the separate install "expect" script with the "--mode unattended" feature of the installer. Hopefully this makes it easier to update for future versions.

I did not remove the setup scripts, but I believe they are no longer needed.