### PR TITLE
Adding a shell script to launch the container and bind user directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,19 @@ Just copy `quartus_sh` to a directory in your `PATH`.
 Environment variables:
 - `JTAG_SERVER`: allows setting a server for remote programming
 - `JTAG_PASSWD`: allows setting a server password for remote programming
+
+
+# Running Quartus GUI from docker 
+To run the quartus as GUI, you can use the shell script
+
+```
+$ launch.sh
+```
+
+This binds your home folder  and user profiles to the container.
+
+To open GUI enter 
+
+```
+# /opt/intelFPGA_lite/20.1/quartus/bin/quartus
+```

--- a/launch.sh
+++ b/launch.sh
@@ -1,0 +1,22 @@
+#!/bin/bash 
+xhost +local:$USER
+
+docker run -it \
+--env="DISPLAY"  \
+--env="QT_X11_NO_MITSHM=1"  \
+--volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
+--workdir="/home/$USER" \
+--volume="/home/$USER:/home/$USER" \
+--volume="/etc/group:/etc/group:ro" \
+--volume="/etc/passwd:/etc/passwd:ro" \
+--volume="/etc/shadow:/etc/shadow:ro" \
+--volume="/etc/sudoers.d:/etc/sudoers.d:ro" \
+--volume="$HOME/host_docker:/home/user/host_docker" \
+--network=host \
+-e LOCAL_USER_ID=`id -u $USER` \
+-e LOCAL_GROUP_ID=`id -g $USER` \
+-e LOCAL_GROUP_NAME=`id -gn $USER` \
+   chriz2600/quartus-lite:latest
+
+
+xhost -local:$USER


### PR DESCRIPTION
Hi, 

This docker is really of great help to me. I wanted to run quartus , but not to install all those dependency stuff.. Thanks for this.

I am adding a shell script to bind user directories and X11. A lot of folks might be looking to run quartus GUI. If you feel thats worth adding, please accept this pull request

Tested in Ubuntu 18.04
user added in docker group to avoid using sudo . 

